### PR TITLE
Update ai-moderator action version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: github/ai-moderator
+      - uses: github/ai-moderator@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           spam-label: 'spam'


### PR DESCRIPTION
This fails when pasted into an action in a repo, adding a version makes the action work ootb and is enough to have dependabot manage it from then on. 