### PR TITLE
Add workflow to update bundle and licenses

### DIFF
--- a/.github/workflows/ci-auto-fix.yml
+++ b/.github/workflows/ci-auto-fix.yml
@@ -1,0 +1,106 @@
+name: Auto-fix CI failures
+
+on:
+  workflow_run:
+    workflows:
+      - Continuous Integration
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-fix:
+    name: Refresh licensed cache and bundle
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+      HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+      HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+    steps:
+      - name: Skip forks
+        id: repo-check
+        run: |
+          if [ "${HEAD_REPO}" != "${GITHUB_REPOSITORY}" ]; then
+            echo "same_repo=false" >> "$GITHUB_OUTPUT"
+            echo "Pull request comes from a fork; skipping auto-fix."
+          else
+            echo "same_repo=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout PR branch
+        if: steps.repo-check.outputs.same_repo == 'true'
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ env.HEAD_REPO }}
+          ref: ${{ env.HEAD_BRANCH }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        if: steps.repo-check.outputs.same_repo == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Setup Ruby
+        if: steps.repo-check.outputs.same_repo == 'true'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install licensed
+        if: steps.repo-check.outputs.same_repo == 'true'
+        run: gem install licensed
+
+      - name: Install npm dependencies
+        if: steps.repo-check.outputs.same_repo == 'true'
+        run: npm install
+
+      - name: Update licensed cache
+        if: steps.repo-check.outputs.same_repo == 'true'
+        run: licensed cache
+
+      - name: Commit licensed cache changes
+        if: steps.repo-check.outputs.same_repo == 'true'
+        env:
+          HEAD_REPO: ${{ env.HEAD_REPO }}
+          HEAD_BRANCH: ${{ env.HEAD_BRANCH }}
+        run: |
+          if git diff --quiet; then
+            echo "No licensed cache changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: refresh licensed cache"
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${HEAD_REPO}.git HEAD:${HEAD_BRANCH}
+
+      - name: Rebuild bundle
+        if: steps.repo-check.outputs.same_repo == 'true'
+        run: npm run bundle
+
+      - name: Commit bundle changes
+        if: steps.repo-check.outputs.same_repo == 'true'
+        env:
+          HEAD_REPO: ${{ env.HEAD_REPO }}
+          HEAD_BRANCH: ${{ env.HEAD_BRANCH }}
+        run: |
+          if git diff --quiet; then
+            echo "No bundle changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: rebuild bundle"
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${HEAD_REPO}.git HEAD:${HEAD_BRANCH}


### PR DESCRIPTION
This adds a new workflow that's intended to run on pull requests when their CI builds fail. It will run `licensed cache` and `npm run bundle`, committing any changes from those. The goal is to reproduce the manual commits I made in a PR like https://github.com/github/ai-moderator/pull/61, without having to get a human involved. I want to make it easier to land Dependabot version updates.

I sampled from https://github.com/github/github-mcp-server/blob/f62ff634c53b94e9cf38a80ee1fc93fef8d532fb/.github/workflows/license-check.yml#L62 for the commit attribution.