### PR TITLE
Update checkout action version from v4 to v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
       models: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: github/ai-moderator@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
small update to bump checkout from v4 to v7 in the readme, noticed this since I was adding this as an agentic workflow to starter workflows