### PR TITLE
Override vulnerable Undici transitives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -281,19 +281,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@actions/artifact/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/@actions/artifact/node_modules/universal-user-agent": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
@@ -2137,16 +2124,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@github/local-action": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@github/local-action/-/local-action-7.0.1.tgz",
@@ -2339,19 +2316,6 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@github/local-action/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
     },
     "node_modules/@github/local-action/node_modules/universal-user-agent": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,12 @@
     "@rollup/rollup-linux-x64-gnu": "*"
   },
   "overrides": {
+    "@actions/github@6.0.1": {
+      "undici": "6.28.0"
+    },
+    "@actions/github@7.0.0": {
+      "undici": "6.28.0"
+    },
     "@typescript-eslint/typescript-estree@6.21.0": {
       "minimatch": "9.0.9"
     }


### PR DESCRIPTION
## Summary

- Resolve the current Undici findings for `ModelsAIModeratorAction / Security`: [#198168](https://github.com/github/vuln-mgmt/issues/198168), [#225845](https://github.com/github/vuln-mgmt/issues/225845), and [#230188](https://github.com/github/vuln-mgmt/issues/230188). The findings are assigned to `@sgoedecke` for this remediation.
- Add exact-version npm overrides for `@actions/github@6.0.1` and `@actions/github@7.0.0`, the two packages that directly request vulnerable Undici 5.x copies under `@github/local-action@7.0.1`.
- Keep the safe production/root `undici@6.28.0` unchanged and avoid a global Undici override.

## Dependency graph

Before:

- `@github/local-action@7.0.1 > @actions/artifact@5.0.3 > @actions/github@6.0.1 > undici@5.29.0`
- `@github/local-action@7.0.1 > @actions/artifact@5.0.3 > @actions/github@6.0.1 > @actions/http-client@2.2.3 > undici@5.29.0` (deduped)
- `@github/local-action@7.0.1 > @actions/github@7.0.0 > undici@5.29.0`
- Production/root: `undici@6.28.0`

After:

- Every lineage above resolves to the existing root `undici@6.28.0`.
- Both nested `undici@5.29.0` lockfile nodes are removed.
- The now-orphaned `@fastify/busboy@2.1.1` lockfile node is removed.
- Production/root remains `undici@6.28.0`.

The initially considered `@github/local-action@7.0.1` ancestor override covered only one physical npm subtree because `@actions/artifact` is hoisted. Exact overrides on the two dependency owners cover both lineages without broadening the production dependency graph.

## Validation

- `npm ci` with the repository-pinned Node.js `20.9.0`
- `npm run format:check`
- `npm run lint`
- `npm run ci-test` — 3 suites, 22 tests passed
- `npm run bundle`; `dist/` remains unchanged
- `npm ls undici @fastify/busboy @actions/github --all` — all Undici paths resolve to `6.28.0`; Busboy is absent
- `npm audit --package-lock-only` — Undici finding removed; total pre-existing dev findings reduced from 9 to 4
- `npm audit --package-lock-only --omit=dev` — 0 vulnerabilities
- Licensed `Check Licenses` and enterprise license compliance checks passed in PR CI
- All PR CI, CodeQL, lint, tests, action integration tests, and generated `dist/` checks passed

Vulnerability scanner re-evaluation and robot-managed finding closure are automatic after merge; no findings should be manually closed.